### PR TITLE
add gatsby-remark-images for images in markdown

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -28,8 +28,8 @@ module.exports = {
       resolve: `gatsby-source-filesystem`,
       options: {
         name: `contents`,
-        path: `${__dirname}/contents`
-      }
+        path: `${__dirname}/contents`,
+      },
     },
     'gatsby-transformer-sharp',
     'gatsby-plugin-sharp',
@@ -53,9 +53,18 @@ module.exports = {
           {
             resolve: `gatsby-remark-autolink-headers`,
             options: {
-              className: "post-toc-anchor"
-            }
-          }
+              className: 'post-toc-anchor',
+            },
+          },
+          {
+            resolve: `gatsby-remark-images`,
+            options: {
+              // It's important to specify the maxWidth (in pixels) of
+              // the content container as this plugin uses this as the
+              // base for generating different widths of each image.
+              maxWidth: 590,
+            },
+          },
         ],
       },
     },
@@ -64,5 +73,5 @@ module.exports = {
     // To learn more, visit: https://gatsby.app/offline
     // 'gatsby-plugin-offline',
   ],
-  pathPrefix: "/",
+  pathPrefix: '/',
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "gatsby-plugin-react-helmet": "^3.0.0",
     "gatsby-plugin-sharp": "^2.0.18",
     "gatsby-remark-autolink-headers": "^2.0.11",
+    "gatsby-remark-images": "^3.0.6",
     "gatsby-remark-katex": "^2.0.6",
     "gatsby-source-filesystem": "^2.0.7",
     "gatsby-transformer-json": "^2.1.6",


### PR DESCRIPTION
This PR adds the gatsby-remark-images plugin for support of referencing images from markdown. I made this in response to https://github.com/cvluca/gatsby-starter-markdown/issues/7

Feel free to ignore if you don't want it in the core project or have another solution.